### PR TITLE
Enforce usage of double quotes around strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,6 @@ module.exports = {
     "import/no-unresolved": "off",
     "max-len": ["error", { "code": 120 }],
     "no-undef": "off",
-    "quotes": "off",
+    "quotes": ["error", "double"],
   }
 }


### PR DESCRIPTION
TC used to have this rule enabled, but not our other apps, I believe we already decided as a team that we prefer double quotes around strings, so let's include this rule in our common config.

See 
https://github.com/conversation/tc/pull/7968