### PR TITLE
Don't allow superfluous parenthesis

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ module.exports = {
     "import/no-extraneous-dependencies": "off",
     "import/no-unresolved": "off",
     "max-len": ["error", { "code": 120 }],
+    "no-extra-parens": ["error", "all", { "nestedBinaryExpressions": false }],
     "no-undef": "off",
     "quotes": ["error", "double"],
   }


### PR DESCRIPTION
Adding this rule disallows superfluous parenthesis, which will help us a lot when running codemods against our older JS.

Example of what is disallowed, and the autocorrection (most convenient part!)
```diff
diff --git a/app/assets/javascripts/views/user_selector_view.js b/app/assets/javascripts/views/user_selector_view.js
index 1682cae866..b90201306d 100644
--- a/app/assets/javascripts/views/user_selector_view.js
+++ b/app/assets/javascripts/views/user_selector_view.js
@@ -56,8 +56,8 @@ export default UserSelectorView = class UserSelectorView extends View {
     this.onChangeClick = this.onChangeClick.bind(this);
     this.selectUser = this.selectUser.bind(this);
 
-    (((({ type: this.type } = options))));
-    (((({ label: this.label } = options))));
+    ({ type: this.type } = options);
+    ({ label: this.label } = options);
 
     this.$el.html(this.template()).hide();
 ```

Example of autofix running on TC: https://github.com/conversation/tc/pull/7980
Why this is an important rule to add: https://github.com/conversation/tc/pull/7978#discussion_r176611764