### PR TITLE
Allow ESlint to ignore JSX multi-line parenthesis

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = {
     "import/no-extraneous-dependencies": "off",
     "import/no-unresolved": "off",
     "max-len": ["error", { "code": 120 }],
-    "no-extra-parens": ["error", "all", { "nestedBinaryExpressions": false }],
+    "no-extra-parens": ["error", "all", { "nestedBinaryExpressions": false, "ignoreJSX": "multi-line" }],
     "no-undef": "off",
     "quotes": ["error", "double"],
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-eslint-config",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Standard TC sharable config for eslint, an extension of airbnb's configuration",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
According to ESlint `no-extra-parens` rule configuration, it is possible to ignore multi-line components, avoiding conflict with the `react/jsx-wrap-multilines` rule.

- Documentation: https://eslint.org/docs/rules/no-extra-parens#ignorejsx
