### PR TITLE
Ignore non dom role attribute when checking aria usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ module.exports = {
     "import/extensions": "off",
     "import/no-extraneous-dependencies": "off",
     "import/no-unresolved": "off",
+    "jsx-a11y/aria-role": ["warn", { ignoreNonDOM: true }],
     "max-len": ["error", { "code": 120 }],
     "no-extra-parens": ["error", "all", { "nestedBinaryExpressions": false, "ignoreJSX": "multi-line" }],
     "no-undef": "off",


### PR DESCRIPTION
It's perfectly valid to use "role" as a prop for things like React Components, but currently eslint is seeing those props and treating it as an error.

We only really care about misused aria roles on actual DOM elements (where they could have a negative effect on the client).