### PR TITLE
Allow import anywhere

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,9 @@
 module.exports = {
   "extends": "airbnb",
+  "parser": "babel-eslint",
+  "parserOptions": {
+    "allowImportExportEverywhere": true
+  },
   "rules": {
     "comma-dangle": ["error", {
       "arrays": "always-multiline",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "homepage": "https://github.com/conversation/tc-eslint-config#readme",
   "dependencies": {
+    "babel-eslint": "^10.1.0",
     "eslint": "3.19.0",
     "eslint-config-airbnb": "15.1.0",
     "eslint-plugin-import": "2.7.0",


### PR DESCRIPTION
This was a bit of a journey for such a small diff in the end, but it unfortunately (for now) involves using a deprecated version of `babel-eslint` to get the job done.

I tried pretty hard to get us onto the latest versions of eslint and babel, but it looks like there were some fundamental changes to how babel works since 7.9.0 (we are currently on 7.4.0 in TC).

So at some point we'll want to upgrade babel itself and the babel config to suit the new 7.9 automatic runtime system, but for now using an older version of `babel-eslint` will let us keep moving with dynamic imports.