### PR TITLE
[RFC] Allow underscore dangle after this

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,9 @@ module.exports = {
       "exports": "never",
       "functions": "ignore"
     }],
+    "no-underscore-dangle": ["error", {
+      "allowAfterThis": true,
+    }],
     "import/extensions": "off",
     "import/no-extraneous-dependencies": "off",
     "import/no-unresolved": "off",


### PR DESCRIPTION
Initial discussion: https://github.com/conversation/tc-donations/pull/1618#pullrequestreview-646623860

At the moment we disallow preceding underscores, which prohibits us from denoting private variables and methods like so:

```js
this._myPrivateVar
this._myPrivateMethod()
```

In the case where this issue first arose, we've worked around this by being explicit:

```js
this.private_myPrivateVar
```

I personally prefer `this._myPrivateVar` - I think it's more concise and widely understood. However, as [the eslint rule docs](https://eslint.org/docs/rules/no-underscore-dangle#options) say,

> As far as naming conventions for identifiers go, dangling underscores may be the most polarizing in JavaScript.

What are everyone's thoughts on this change?