### PR TITLE
Upgrade eslint to 4.12.1

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,6 @@
+// ref https://github.com/airbnb/javascript/blob/eslint-config-airbnb-v15.1.0/packages/eslint-config-airbnb-base/rules/variables.js
+const restrictedGlobals = require('eslint-restricted-globals');
+
 module.exports = {
   "extends": "airbnb",
   "parser": "babel-eslint",
@@ -12,6 +15,7 @@ module.exports = {
       "exports": "never",
       "functions": "ignore"
     }],
+    "function-paren-newline": 0,
     "import/extensions": "off",
     "import/no-extraneous-dependencies": "off",
     "import/no-unresolved": "off",
@@ -19,6 +23,8 @@ module.exports = {
     "max-len": ["error", { "code": 120 }],
     "no-extra-parens": ["error", "all", { "nestedBinaryExpressions": false, "ignoreJSX": "multi-line" }],
     "no-undef": "off",
+    "no-restricted-globals": ["off"].concat(restrictedGlobals),
+    "object-curly-newline": 0,
     "quotes": ["error", "double"],
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
   "homepage": "https://github.com/conversation/tc-eslint-config#readme",
   "dependencies": {
     "babel-eslint": "^10.1.0",
-    "eslint": "3.19.0",
-    "eslint-config-airbnb": "15.1.0",
+    "eslint": "4.12.1",
+    "eslint-config-airbnb": "16.1.0",
     "eslint-plugin-import": "2.7.0",
-    "eslint-plugin-jsx-a11y": "5.1.1",
-    "eslint-plugin-react": "7.1.0"
+    "eslint-plugin-jsx-a11y": "6.0.2",
+    "eslint-plugin-react": "7.4.0"
   }
 }


### PR DESCRIPTION
This fixes a dependency conflict in `eslint-plugin-import` where it requires 4.12.1 or higher, while trying not to introduce too much churn in how the lint rules are being enforced.

There are quite a few new rules I've left on because they are more sensible than what we've currently got and I don't think they will be controversial (feel free to discuss):

### Use object destructuring 

```jsx
// before
signal.subscribe((e) => {
  onRefresh = e.onRefresh;

  ...
});

// after
signal.subscribe(({ onRefresh }) => {
  ...
});
```

### Curly braces are unnecessary here 

```jsx
// before
const wrapper = mount(<ContentInline {...props} body={"promo body"} />);

// after
const wrapper = mount(<ContentInline {...props} body="promo body" />);
```

### Typo in declared prop type

```jsx
// before
PropTypes.integer

// after
PropTypes.Integer
```

### Anchor used as a button. Use the button element instead

```jsx
// before
<a href="#" onClick={clearFilter}>

// after
<button onClick={clearFilter}>
```
There are also a bunch of failures to do with slight changes in indentation rules and semi colon placement, but they are so minor and obviously better I didn't bother listing them. Same goes for things like missing form labels, obvious mistake that we want a rule to pick up on.

If you are curious to test this either in TC or any other app you can install by changing the package.json entry for `tc-eslint-config` to point to `github:conversation/tc-eslint-config#0158d86`. Failures are expected, will perhaps get Tiago to help with making some of the changes needed to pass the new lint rules.